### PR TITLE
added the clusterer image

### DIFF
--- a/public/js/atlas.js
+++ b/public/js/atlas.js
@@ -265,7 +265,7 @@ function Icons() {
     if (clustersEnabled) {
         icons = {
             Other: {
-                icon: "https://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m1.png",
+                icon: "https://googlemaps.github.io/js-marker-clusterer/images/m1.png",
                 label: "Other"
             }
         };


### PR DESCRIPTION
There isn't any issue reported for this problem and 
Issue is  : if clustering is enabled by checking the clustering in view dropdown at [atlas.openmrs.org](https://atlas.openmrs.org/), it should show the clustering of pins but that won't show up since the markercluster code is moved to the Github. 

I changed the code locally and it works fine after this fix.