### PR TITLE
Added authentication check for post routes

### DIFF
--- a/routes/markerSites.js
+++ b/routes/markerSites.js
@@ -3,6 +3,15 @@ var router = express.Router();
 var uuid = require('uuid');
 
 module.exports = function(connection) {
+    /* Middleware to check whether the user is logged in */
+    function isAuthenticated(req, res, next) {
+        if(req.session.authenticated) {
+            return next();
+        } else {
+            res.redirect("/login");
+        }
+    };
+
     /* GET all the markerSites */
     router.get('/markerSites', function(req, res, next) {
 
@@ -57,7 +66,7 @@ module.exports = function(connection) {
     });
 
     //POST /marker/:id
-    router.post('/marker/', function (req, res, next) {
+    router.post('/marker/', isAuthenticated, function (req, res, next) {
         var id=uuid.v4();
         var latitude=req.body.latitude;
         var longitude=req.body.longitude;
@@ -94,7 +103,7 @@ module.exports = function(connection) {
         });
     });
 
-    router.post('/marker/:id', function (req, res, next) {
+    router.post('/marker/:id', isAuthenticated, function (req, res, next) {
 
         var id=req.params['id'];
         var latitude=req.body.latitude;


### PR DESCRIPTION
Based on [this issue](https://github.com/ShekharReddy4/openmrs-contrib-atlas-node/issues/4). Weirdly, I couldn't test the code I wrote, as the '/login/' route leads to 'http://localhost:8080/authenticate/atlas' which I don't know how to set up. If I can get that url running, I think I could test and confirm whether my code does the job.