### PR TITLE
Fetch only visible markers to display on the map

### DIFF
--- a/public/js/atlas.js
+++ b/public/js/atlas.js
@@ -214,7 +214,7 @@ function initialize() {
 }
 
 function fetchMarkerSites() {
-    $.ajax({url: "/markerSites"})
+    $.ajax({url: "/visibleMarkerSites"})
         .always(function (data, textStatus) {
             if (textStatus != "success") {
                 bootbox.alert("Error fetching data for sites ! - " + data.statusText);

--- a/routes/markerSites.js
+++ b/routes/markerSites.js
@@ -28,6 +28,22 @@ module.exports = function(connection) {
 
     });
 
+    /* GET all visible markerSites */
+    router.get('/visibleMarkerSites', function(req, res, next) {
+
+        connection.query("SELECT * FROM atlas WHERE date_changed > CURDATE() - INTERVAL 2 YEAR", function (error, rows, field) {
+            if(!!error){
+                console.log(error);
+            }
+            else{
+                //var data  = JSON.stringify(rows);
+                res.setHeader('Content-Type', 'application/json');
+                res.json(rows);
+            }
+        });
+
+    });
+    
     /* Get a specific marker with uid parameter */
     router.get('/marker/:id', function (req, res, next) {
 


### PR DESCRIPTION
@cintiadr Currently all the markers are being fetched into the map, even the ones won't be appearing(Currently, there are around 40 visible markers on the map, but 370 markers are getting fetched). Markers that haven't been updated in the last 2 years aren't visible on the atlas, as seen here.
```
function getFadeGroup(site) {
    var ageInMonths = Math.max(0, (new Date().getTime() - dateForSite(site)) / 2592000000); // milliseconds in 30 days
    var fadeGroup = Math.floor(ageInMonths / 6);
    return Math.min(fadeGroup, 4); // higher index == more transparent (max is 4, complete transparency)
}
```
So I created a route that fetches only visible markers and am using it to display marker data on the map.