### PR TITLE
ATLAS-134: Check and store whether user is admin on login

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@ app.use(cookieParser());
 app.use(expressSession(
     {
         secret: process.env.SESSION_SECRET || 'secret',
+        name: 'atlasCookie',
         saveUninitialized:false,
         resave:false
     }));

--- a/conf.example.js
+++ b/conf.example.js
@@ -12,5 +12,10 @@ module.exports = {
       "baseDn": "ou=users,dc=openmrs,dc=org",
       "rdn": "uid",
     },
+    "group": {
+      "baseDn": "ou=groups,dc=openmrs,dc=org",
+      "member": "member",
+      "rdn": "cn",
+    }
   },
 };


### PR DESCRIPTION
@cintiadr @bmamlin @harsha89 Whether the user is an admin or not is now stored in the user session object.

Here's a sample user session object.
```
{ dn: 'uid=testadmin,ou=users,dc=openmrs,dc=org',
  controls: [],
  uid: 'testadmin',
  cn: 'Admin',
  sn: 'User',
  displayName: 'Test Admin User',
  mail: 'testadminuser@gmail.com',
  admin: true }
```

I'm starting to think that maybe a flag wouldn't be the best idea if the user belonged to multiple groups. Maybe its better to ignore that for now, as mentioned my @bmamlin on talk yesterday. What do you think? :)