### PR TITLE
ATLAS-135: Change markerSites to markers in the marker API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,6 @@ services:
       - 3000:3000
     restart: always
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/markerSites/"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/markers/"]
 volumes:
   mysql-data:

--- a/public/js/atlas.js
+++ b/public/js/atlas.js
@@ -214,7 +214,7 @@ function initialize() {
 }
 
 function fetchMarkerSites() {
-    $.ajax({url: "/markerSites"})
+    $.ajax({url: "/markers"})
         .always(function (data, textStatus) {
             if (textStatus != "success") {
                 bootbox.alert("Error fetching data for sites ! - " + data.statusText);

--- a/routes/markerSites.js
+++ b/routes/markerSites.js
@@ -20,10 +20,18 @@ module.exports = function(connection) {
         }
     }
 
-    /* GET all the markerSites */
-    router.get('/markerSites', function(req, res, next) {
+    /* GET all the markers */
+    router.get('/markers', function(req, res, next) {
 
-        connection.query("SELECT * FROM atlas", function (error, rows, field) {
+        var query="SELECT * FROM atlas";
+
+        //filter by username
+        var username=req.query['username'];
+        if(username) {
+            query += " WHERE created_by='"+username+"'";
+        }
+
+        connection.query(query, function (error, rows, field) {
             if(!!error){
                 console.log(error);
             }
@@ -37,26 +45,7 @@ module.exports = function(connection) {
 
     });
 
-    /* Get a specific marker with uid parameter */
-    router.get('/marker/uid/:uid', function (req, res, next) {
-
-        var uid=req.params['uid'];
-        console.log(uid);
-        connection.query('select * from atlas where created_by=?',[uid], function (error, rows, field) {
-
-            if(!!error){
-                console.log(error);
-            }
-            else {
-                res.setHeader('Content-Type', 'application/json');
-                filterMarkerIds(req, rows);
-                res.json(rows);
-                //connection.end();
-            }
-        })
-    });
-
-    /* Get a specific marker with uid parameter */
+    /* Get a specific marker with id parameter */
     router.get('/marker/:id', function (req, res, next) {
 
         var id=req.params['id'];

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -115,7 +115,7 @@
 
       //If user is logged in
       if(currentUser != "visitor") {
-        $.ajax({url: "/marker/uid/"+currentUser})
+        $.ajax({url: "/markers?username="+currentUser})
           .always(function (data, textStatus) {
               if (textStatus != "success") {
                   bootbox.alert("Error fetching data for sites ! - " + data.statusText);


### PR DESCRIPTION
Changed `GET /markerSites` to `GET /markers` and replaced `GET /marker/uid/:uid` with `GET /markers?username={username}`.