### PR TITLE
ATLAS-150: Add checks in the API before the sql syntax is executed

### DIFF
--- a/routes/markerSites.js
+++ b/routes/markerSites.js
@@ -85,6 +85,10 @@ module.exports = function(connection) {
 
     /* Create new marker */
     router.post('/marker/', utils.isAuthenticated, function (req, res, next) {
+
+        //If authenticated user is not the owner of the marker or an admin, return 401 (Unauthorized)
+        if(req.session.user.uid != req.body.uid && !req.session.user.admin) return res.send(401);
+
         req.body = JSON.parse(Object.keys(req.body)[0]);
         var id=uuid.v4();
         var latitude=req.body.latitude;
@@ -123,6 +127,10 @@ module.exports = function(connection) {
 
     /* Update marker with given id */
     router.patch('/marker/:id', utils.isAuthenticated, function (req, res, next) {
+
+        //If authenticated user is not the owner of the marker or an admin, return 401 (Unauthorized)
+        if(req.session.user.uid != req.body.uid && !req.session.user.admin) return res.send(401);
+
         req.body = JSON.parse(Object.keys(req.body)[0]);
         var id=req.params['id'];
         var latitude=req.body.latitude;


### PR DESCRIPTION
@bmamlin @harsha89 @cintiadr Checking whether the marker belongs to the authenticated user, or whether the user is an admin before executing the create/edit marker SQL.