### PR TITLE
ATLAS-154: Show hidden counts only to creator and admins

### DIFF
--- a/public/js/user.js
+++ b/public/js/user.js
@@ -228,6 +228,9 @@ function saveMarker(e) {
     var patients = $("#patients").val().trim();
     var encounters = $("#encounters").val().trim();
     var obs = $("#observations").val().trim();
+    if(patients==='') patients=0;
+    if(encounters==='') encounters=0;
+    if(obs==='') obs=0;
     var version = $("select#version").val().trim();
     site.distribution = getSelectedDistributionValue();
     site.nonStandardDistributionName = $("#nonStandardDistributionName").val().trim();
@@ -240,7 +243,7 @@ function saveMarker(e) {
     var stats = $('#include-count').is(':checked') ? 1 : 0;
     site.show_counts = stats;
   }
-
+  
   var image = $("#image").val();
   var name = $("#name").val().trim();
   var mail = $("#email").val().trim();
@@ -330,7 +333,7 @@ function contentInfowindow(site) {
   if (site.url)
     html += "<div class='site-url'><a target='_blank' rel='nofollow' href='" + safeUrl(site.url) + "' title='" + site.url + "'>"
         + displayUrl(safeUrl(site.url)) + "</a></div>";
-  if (site.show_counts == true) {
+  if (site.show_counts == true || isAdmin) {
     if (site.patients && site.patients !== "0")
       html += "<div class='site-count'>" + addCommas(site.patients) + " patients</div>";
     if (site.encounters && site.encounters !== "0")
@@ -368,9 +371,6 @@ function contentInfowindow(site) {
 }
 
 function contentEditwindow(site) {
-  var patients = ('patients' in counts) ? counts.patients : ('patients' in site) ? site.patients : "?";
-  var encounters = ('encounters' in counts) ? counts.encounters : ('encounters' in site) ? site.encounters : "?";
-  var observations = ('observations' in counts) ? counts.observations : ('observations' in site) ? site.observations : "?";
   var html = "<div class='site-bubble bubble-form'>";
   html += "<form method='post' id='"+ site.id +"'>";
   html += "<div class='form-group'><input type='text' required='true' placeholder='Site Name' title='Site Name' class='form-control input-sm' value='"+ site.name + "' id='name' name='name'></div>";
@@ -381,7 +381,7 @@ function contentEditwindow(site) {
   html += "<div class='form-group'><textarea class='form-control' value='' name='notes' rows='2' id='notes' placeholder='Notes'>"+ site.notes + "</textarea></div>";
 
   html += createDistributionSelectBox(site.distribution, site.nonStandardDistributionName);
-
+  
   if (site.module !== 1) {
     html += "<div class='site-stat'>";
     html += "<div class='form-inline'>Patients <input type='number' pattern='[0-9]' class='form-control input-sm' title='Number of patients' value='"+ site.patients + "' name='patients' id ='patients'></div>";
@@ -396,6 +396,7 @@ function contentEditwindow(site) {
     html += "<div class='form-inline'>" + observations + " observations</div>";
     html += "</div></fieldset>";
   }
+
   if (site.module !== 1) {
     html += "<div class='form-inline'> OpenMRS Version ";
     html += "<select title='OpenMRS Version' id='version' class='form-control input-sm'>";

--- a/routes/markerSites.js
+++ b/routes/markerSites.js
@@ -13,10 +13,20 @@ module.exports = function(connection) {
         }
     }
 
+    var show_counts_query = "SELECT * FROM atlas";
+
+    var no_counts_query = "SELECT id,latitude,longitude,name,url,type,image,show_counts, \
+    IF(show_counts, patients, null) AS patients, \
+    IF(show_counts, encounters, null) AS encounters, \
+    IF(show_counts, observations, null) as observations, \
+    contact,email,notes,data,atlas_version,openmrs_version,distribution,date_created,date_changed,created_by FROM atlas";
+
     /* GET all the markers */
     router.get('/markers', function(req, res, next) {
 
-        var query = "SELECT * FROM atlas";
+        var query = "";
+        if(req.session.authenticated && req.session.user.admin) query = show_counts_query;
+        else query = no_counts_query;
 
         //filter by url
         var criteria = [
@@ -66,9 +76,13 @@ module.exports = function(connection) {
     /* Get a specific marker with id parameter */
     router.get('/marker/:id', function (req, res, next) {
 
+        var query = "";
+        if(req.session.authenticated && req.session.user.isAdmin) query = show_counts_query;
+        else query = no_counts_query;
+
         var id=req.params['id'];
         console.log(id);
-        connection.query('select * from atlas where id=?',[id], function (error, rows, field) {
+        connection.query(query+' where id=?',[id], function (error, rows, field) {
 
             if(!!error){
                 console.log(error);


### PR DESCRIPTION
@bmamlin @harsha89 @cintiadr If show counts is off, only creator and admins can view it. Currently counts are being returned but are being hidden by the front end, which isn't the way it should be done. What do you think is a good way to avoid this?

I could think of using an SQL statement likeL
```
SELECT * FROM atlas WHERE show_counts=1
UNION (SELECT <columns except counts> FROM WHERE show_counts=0);
```
Another way I could think of is to write a JS function to filter out counts on the server.

JIRA issue: https://issues.openmrs.org/browse/ATLAS-154

![Screenshot from 2019-06-21 23-09-36](https://user-images.githubusercontent.com/34064492/59941102-0a39ec80-947a-11e9-8136-86bb6c99229b.png)

