### PR TITLE
ATLAS-158: Fixed versions dropdown in the edit marker bubble

### DIFF
--- a/public/js/user.js
+++ b/public/js/user.js
@@ -34,13 +34,6 @@ $(function () {
       if (result) deleteMarker(id);
     });
   });
-  $("#map_canvas").on("focus", "#version", function(e){
-    $("#version").html("");
-    $("#version").append("<option value=''></option>");
-    $(existingVersion).each(function (i) {
-      $("#version").append("<option value=\""+existingVersion[i]+"\">"+existingVersion[i]+"</option>");
-    });
-  });
 });
 
 function getGeolocation() {


### PR DESCRIPTION
It displays the version correctly at first, but empties and closes automatically on clicking on it.

JIRA issue: https://issues.openmrs.org/browse/ATLAS-158