### PR TITLE
ATLAS-159: Legend isn't being updated until the page is refreshed

### DIFF
--- a/public/js/user.js
+++ b/public/js/user.js
@@ -305,6 +305,7 @@ function saveMarker(e) {
           if (auth_site.length > 0)
             $("#editSite").attr("hidden", false);
           repaintMarkers();
+          initLegend();
           bootbox.alert("Marker saved");
           if (site.distribution == null && (site.nonStandardDistributionName != null && site.nonStandardDistributionName != "")) {
             fetchDistributions()


### PR DESCRIPTION
When a new marker is created or an existing is updated, the legend isn't being updated.

JIRA issue: https://issues.openmrs.org/browse/ATLAS-159