### PR TITLE
ATLAS-161: Viewing markers by distributions marks all markers as 'Other'

### DIFF
--- a/public/js/atlas.js
+++ b/public/js/atlas.js
@@ -311,7 +311,9 @@ function Icons() {
             return distribution.is_standard == true;
         });
 
-        sites.forEach(function(site){
+        Object.keys(sites).forEach(function(siteid){
+            var site = sites[siteid];
+            
             var siteDistribution = standardDistributions.find(function(distribution){
                 return distribution.id == site.siteData.distribution;
             });


### PR DESCRIPTION
View --> Distros, marks every marker as 'Other' and colors them purple.

JIRA issue: https://issues.openmrs.org/browse/ATLAS-161

On Atlas staging:
![Screenshot from 2019-06-26 14-36-28](https://user-images.githubusercontent.com/34064492/60167034-e7b02680-981f-11e9-96de-61d5afe575e4.png)

After the fix on my pc:
![Screenshot from 2019-06-26 14-36-04](https://user-images.githubusercontent.com/34064492/60167087-06aeb880-9820-11e9-9a2f-cd9a8317ed53.png)
