### PR TITLE
ATLAS-176: Make it easier for a user to spot his own markers

### DIFF
--- a/public/css/atlas.css
+++ b/public/css/atlas.css
@@ -356,7 +356,7 @@ span.site-version {
     margin-top : -10px;
     margin-bottom: 5px;
 }
-#fade input[type=checkbox], #legend-group input[type=checkbox], #legend-clusters input[type=checkbox] {
+#fade input[type=checkbox], #legend-group input[type=checkbox], #legend-clusters input[type=checkbox], #mymarkers input[type=checkbox] {
 -ms-transform: scale(0.8); /* IE */
   -moz-transform: scale(0.8); /* FF */
   -webkit-transform: scale(0.8); /* Safari and Chrome */
@@ -368,7 +368,7 @@ span.site-version {
   left: -3px;
   *overflow: hidden;
 }
-#fade label, #legend-group label, #legend-clusters label {
+#fade label, #legend-group label, #legend-clusters label, #mymarkers label {
     display: block;
     padding-left: 15px;
     text-indent: -15px;

--- a/public/js/atlas.js
+++ b/public/js/atlas.js
@@ -40,6 +40,10 @@ function initLegendChoice() {
         repaintMarkers();
         initLegend();
     });
+    $("#mymarkers-checkbox").click(function () {
+        showAllMarkers = !showAllMarkers;
+        repaintMarkers();
+    });
 }
 
 function clickLegend(id) {
@@ -461,7 +465,7 @@ function repaintMarkers() {
         var opacity = 1;
         if (fadeOverTime)
             opacity = (1 - (site.fadeGroup * 0.25));
-        if (shouldBeVisible(site.fadeGroup)) {
+        if (shouldBeVisible(site.fadeGroup) && (showAllMarkers || site.siteData.created_by == currentUser)) {
             site.marker.setIcon(colorForSite(site.siteData));
             site.marker.setVisible(true);
             site.marker.setOpacity(opacity);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -50,6 +50,7 @@
     var shadows = [];
     var fadeOverTime = true;
     var legendGroups = 0;
+    var showAllMarkers = true;
     var viewParam = {
       site : null,
       position : new google.maps.LatLng(15,15),
@@ -201,6 +202,12 @@
     <div class = "dropDownItemDiv" id="legend-clusters" title="Enable markers clustering.">
       <label><input type="checkbox" id="clusters-checkbox"><b>Clustering</b></label>
     </div>
+
+    <% if (user) { %>
+      <div class = "dropDownItemDiv" id="mymarkers" title="Display only user's markers.">
+        <label><input type="checkbox" id="mymarkers-checkbox"><b>My Markers</b></label>
+      </div>
+    <% } %>
 
   </div>
 


### PR DESCRIPTION
Added a "My Markers" checkbox under "View" to display only the user's markers, as suggested by @cintiadr .

JIRA issue: https://issues.openmrs.org/browse/ATLAS-176?jql=project%20%3D%20ATLAS

![Screenshot from 2019-07-03 22-51-45](https://user-images.githubusercontent.com/34064492/60611957-3abc4780-9de5-11e9-8a6a-a53564c495ae.png)

![Screenshot from 2019-07-03 22-51-54](https://user-images.githubusercontent.com/34064492/60611967-3db73800-9de5-11e9-81f0-dad7a6dbef60.png)
