### PR TITLE
ATLAS-185: Deleting or updating invalid marker crashes server

### DIFF
--- a/routes/markers.js
+++ b/routes/markers.js
@@ -190,6 +190,9 @@ module.exports = function(connection) {
                 console.log(error);
                 return res.status(500).send({ message: "Error retrieving data from database"});
             }
+            else if(!rows || rows.length === 0) {
+                return res.status(404).send({ message: "Marker not found"});
+            }
             else if(rows[0].created_by != req.session.user.uid && !req.session.user.admin) {
                 return res.send(401);
             } else {
@@ -290,6 +293,8 @@ module.exports = function(connection) {
             if(error) {
                 console.log(error);
                 return res.status(500).send({ message: "Error retrieving data from database"});
+            } else if (!rows || rows.length === 0) {
+                return res.status(404).send({ message: "Marker not found"});
             } else if (rows[0].created_by != req.session.user.uid && !req.session.user.admin) {
                 res.send(401);
             } else {


### PR DESCRIPTION
Handle the condition where a marker is not found, returning at 404 Not Found to the client.