### PR TITLE
ATLAS-199: Site fade tip text extending beyond bubble

### DIFF
--- a/public/css/atlas.css
+++ b/public/css/atlas.css
@@ -382,8 +382,9 @@ span.site-version {
     color: rgba(141, 141, 141, 1);
     position: absolute;
     padding-bottom: 2px;
-    left:12px;
+    left:-40px;
     bottom:1px;
+    z-index: 1;
 }
 .toggle {
         cursor:pointer;


### PR DESCRIPTION
JIRA issue: https://issues.openmrs.org/browse/ATLAS-199

Adding the tooltip to the info container disables the tooltip (hovering doesn't display the tooltip).
This is the fastest solution I could think of. :/