### PR TITLE
ATLAS-194: Create module mode

### DIFF
--- a/public/js/atlas.js
+++ b/public/js/atlas.js
@@ -239,6 +239,9 @@ function fetchMarkerSites() {
             $.ajax({url: "/api/auth"})
             .always(function (authrules, textStatus) {
                 loadSites(data, authrules);
+
+                if(moduleMode === "true") getModuleMarker(moduleUUID, moduleToken);
+
                 var marker_id = document.getElementById('marker-id').value;
                 var update_marker = document.getElementById('update-marker').value;
                 var delete_marker = document.getElementById('delete-marker').value;
@@ -440,12 +443,12 @@ function colorForSite(site) {
         var key = distribution && icons.hasOwnProperty(distribution.name) ? distribution.name : "Other";
         image.url = icons[key].icon;
     }
-    if ((isMyMarker(site) || auth_site.indexOf(site.uuid) !== -1) && legendGroups === 2
+    if ((isMyMarker(site) || auth_site.indexOf(site.id) !== -1) && legendGroups === 2
         && moduleHasSite !== 1 && !clustersEnabled)
         image.url = "https://maps.google.com/intl/en_us/mapfiles/ms/micons/blue-dot.png";
     if ((site.module === 1 && legendGroups === 2 && moduleUUID !== null && moduleHasSite === 1 && !clustersEnabled)) {
         image.url = "https://maps.google.com/intl/en_us/mapfiles/ms/micons/blue-dot.png";
-    } else if ((isMyMarker(site) || auth_site.indexOf(site.uuid) !== -1)
+    } else if ((isMyMarker(site) || auth_site.indexOf(site.id) !== -1)
         && legendGroups === 2 && (moduleUUID === null || moduleHasSite === 0) && !clustersEnabled) {
         image.url = "https://maps.google.com/intl/en_us/mapfiles/ms/micons/blue-dot.png";
     }
@@ -500,7 +503,7 @@ function loadSites(json, authrules) {
             editwindow = createEditInfoWindow(site, marker);
         if (site.openmrs_version)
             version.push(versionMajMinForSite(site));
-        if (moduleHasSite !== 1 && auth_site.indexOf(site.uuid) !== -1 && moduleUUID !== null && auth_site.length === 1)
+        if (moduleHasSite !== 1 && auth_site.indexOf(site.id) !== -1 && moduleUUID !== null && auth_site.length === 1)
             uniqueMarker = marker;
         sites[site.id] = {
             "siteData": site,
@@ -703,20 +706,7 @@ function createInfoWindow(site, marker) {
             infowindow.open(map, marker);
             sites[site.id].bubbleOpen = true;
             $("#undo").remove();
-            if (moduleHasSite !== 1 && site.uuid !== null && moduleUUID !== null
-                && currentUser !== "visitor" && auth_site.indexOf(site.uuid) !== -1
-                && $(".site-bubble").has("#me-button").length == 0) {
-                html = "<div class='me-button'><button type='button' id='me-button' value='" + site.id + "' title='Pick the site for this server.'";
-                html += "class='btn btn-success btn-xs'>This is me !</button></div>";
-                $(".site-bubble").append(html);
-            } else if (site.module === 1 && moduleHasSite === 1 && currentUser !== "visitor"
-                && auth_site.indexOf(site.uuid) !== -1
-                && $(".site-bubble").has("#detach-button").length == 0) {
-                html = "<div class='me-button'><button type='button' id='detach-button' value='" + site.id + "' title='Detach the site from this server.'";
-                html += "class='btn btn-info btn-xs'>This is not me.</button></div>";
-                $(".site-bubble").append(html);
-            }
-            if (canUpdate(site) || site.uuid !== null) {
+            if (canUpdate(site) || site.id !== null) {
                 if ($(".gm-style-iw").parent().has("#edit").length == 0) {
                     $("#lock").remove();
                     $(".gm-style-iw").parent().append("<div id='edit' value='" + site.id + "' title ='Edit site' class='control' style='position: absolute;overflow:none; right:12px;bottom:12px; color:#3F3F3F'><i class='fa fa-lg fa-pencil' style='color:rgba(171, 166, 166, 1)'></i></div>");

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -569,6 +569,17 @@ function contentInfowindow(site) {
   if(site.created_by === currentUser || isAdmin) {
     html += "<div id='delete' value='" + site.id + "' title ='Delete site' class='control' style='position: absolute;overflow:none; right:12px;bottom:27px; color:#3F3F3F'><i class='fa fa-lg fa-trash-o' style='color:rgba(171, 166, 166, 1)'></i></div>";
   }
+
+  if (site.module === 1 && moduleHasSite === 1 && currentUser !== "visitor"
+      && auth_site.indexOf(site.id) !== -1) {
+      html += "<div class='me-button'><button type='button' id='detach-button' value='" + site.id + "' title='Detach the site from this server.'";
+      html += "class='btn btn-info btn-xs'>This is not me.</button></div>";
+  } else if (site.id !== null && moduleUUID !== null
+    && currentUser !== "visitor" && auth_site.indexOf(site.id) !== -1) {
+    html += "<div class='me-button'><button type='button' id='me-button' value='" + site.id + "' title='Pick the site for this server.'";
+    html += "class='btn btn-success btn-xs'>This is me !</button></div>";
+  }
+
   html += "</div>";
   return html;
 }

--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -7,10 +7,12 @@ logger.level = 'debug';
 
 module.exports = function(connection) {
 
+    var get_auth_query = "SELECT id, atlas_id, principal, privileges, expires from auth";
+
     /* Get all auth rules */
     router.get('/auth', function (req, res, next) {
 
-        connection.query('select * from auth', function (error, rows, field) {
+        connection.query(get_auth_query, function (error, rows, field) {
 
             if(!!error){
                 logger.error(error);
@@ -77,7 +79,7 @@ module.exports = function(connection) {
             return res.send(400);
         }
 
-        connection.query("SELECT * FROM auth WHERE id=?", [id], function (error, rows, field) {
+        connection.query(get_auth_query + " WHERE id=?", [id], function (error, rows, field) {
 
             if(error) {
                 logger.error(error);

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -13,4 +13,5 @@ module.exports = function(app, db) {
     importRoute('versions');
     importRoute('auth');
     importRoute('unsubscribed');
+    importRoute('module');
 };

--- a/routes/api/markers.js
+++ b/routes/api/markers.js
@@ -339,28 +339,6 @@ module.exports = function(connection) {
         });
     });
 
-    /* Update marker with given id (called by atlas module) */
-    router.post('/module/ping.php', utils.isAuthenticated, function (req, res, next) {
-        console.log(req.body);
-        var id=req.body.id;
-        var patients=req.body.patients;
-        var encounters=req.body.encounters;
-        var observations=req.body.observations;
-        var data=req.body.data;
-        var date_changed=new Date().toISOString().slice(0, 19).replace('T', ' ');
-        var openmrs_version=data.version;
-
-        connection.query('UPDATE atlas SET patients=?,encounters=?,observations=?,data=?,date_changed=?,openmrs_version=? WHERE id =?', [patients,encounters,observations,data,date_changed,openmrs_version,id], function (error, rows,field) {
-            if(!!error){
-                console.log(error);
-            }
-            else {
-                res.setHeader('Content-Type', 'application/json');
-                res.json(id);
-            }
-        });
-    });
-
     /* Delete marker with given id */
     router.delete('/marker/:id', utils.isAuthenticated, function(req, res, next) {
 
@@ -403,22 +381,5 @@ module.exports = function(connection) {
         });
     });
 
-    /* Delete marker with given id (called by atlas module) */
-    router.delete('/module', utils.isAuthenticated, function(req, res, next) {
-
-        var id=req.query['id'];
-        var secret=req.query['secret'];
-
-        connection.query('DELETE FROM atlas WHERE id =?', [id], function (error, rows,field) {
-            if(!!error){
-                logger.error(error);
-            }
-            else {
-                res.setHeader('Content-Type', 'application/json');
-                res.json(id);
-            }
-        });
-    });
-        
     return router;
 };

--- a/routes/api/module.js
+++ b/routes/api/module.js
@@ -1,0 +1,132 @@
+var express = require('express');
+var router = express.Router();
+var utils = require('../../utils');
+var bcrypt = require('bcrypt');
+var logger = require('log4js').getLogger();
+logger.level = 'debug';
+
+module.exports = function(connection) {
+
+    var show_counts_query = "SELECT id,latitude,longitude,name,url,type, \
+    IF(image is not null, concat(?,'://',?,'/marker/',id,'/image'), null) AS image_url, \
+    show_counts,patients,encounters,observations,contact,email,notes,data,openmrs_version,distribution,date_created,date_changed,created_by FROM atlas";
+
+    /* Add marker update rights for module */
+    router.post('/module/auth', utils.isAuthenticated, function (req, res, next) {
+
+        var module_id=req.session.module_id;
+        var token=req.session.module_token;
+        var atlas_id=req.body.atlas_id;
+
+        if(!utils.isUUID(module_id) || !utils.isUUID(token) || !utils.isUUID(atlas_id)) {
+            return res.send(400);
+        }
+
+        connection.query('SELECT * FROM auth WHERE principal=? AND atlas_id=? AND (privileges=? OR privileges=?)', [req.session.user.uid,atlas_id,"UPDATE","ALL"], function (error, rows, field) {
+                
+            if(!!error){
+                logger.error(error);
+            } else if (rows && rows.length > 0) {
+
+                connection.query('DELETE FROM auth WHERE principal=?', [module_id], function (error, rows, field) {
+
+                    if(error) {
+                        logger.error(error);
+                    } else {
+                        utils.hashToken(token).then(function(token) {
+                            connection.query('INSERT INTO auth(atlas_id,principal,token,privileges) VALUES(?,?,?,?)', [atlas_id,module_id,token,"UPDATE"], function (error, rows, field) {
+                                if(!!error){
+                                    logger.error(error);
+                                } else {
+                                    res.setHeader('Content-Type', 'application/json');
+                                    res.json({ id: rows.insertId, atlas_id: atlas_id, principal: "module", privileges: "UPDATE", expires: null });           
+                                }
+                            });                                
+                        });        
+                    }
+                });
+            } else {
+                res.send(401);
+            }
+        });
+    });
+
+    router.post(['/module/ping', '/module/ping.php'], function(req, res, next) {
+        var module_id=req.body.id;
+        var token=req.body.token;
+        if(!utils.isUUID(module_id) || !utils.isUUID(token)) {
+            return res.send(400);
+        }
+
+        connection.query('SELECT * FROM auth WHERE principal=? AND privileges=?', [module_id,"UPDATE"], function (error, rows, field) {
+            if(!!error){
+                logger.error(error);
+            } else if(rows && rows.length > 0) {
+
+                bcrypt.compare(token, rows[0].token, function(err, resp) {
+
+                    if(!resp) return res.send(401);
+
+                    var patients=req.body.patients;
+                    var observations=req.body.observations;
+                    var encounters=req.body.encounters;
+                    var data=req.body.data;
+                    var date_changed=new Date();
+                    var openmrs_version=data.version;
+                    data=JSON.stringify(data);
+
+                    if(!patients || patients === '') patients = 0;
+                    if(!observations || observations === '') observations = 0;
+                    if(!encounters || encounters === '') encounters = 0;
+            
+                    connection.query('UPDATE atlas SET patients=?,observations=?,encounters=?,data=?,date_changed=?,openmrs_version=? WHERE id=?', [patients,observations,encounters,data,date_changed,openmrs_version,rows[0].atlas_id], function (error, rows, field) {
+                        if(!!error){
+                            logger.error(error);
+                        } else {
+                            res.setHeader('Content-Type', 'application/json');
+                            res.send(req.body);
+                        }
+                    });
+                });
+            } else {
+                res.send(401);
+            }
+        });
+    });
+
+    /* Get marker related to module */
+    router.delete('/module/auth',  utils.isAuthenticated, function (req, res, next) {
+
+        var module_id=req.session.module_id;
+        var token=req.session.module_token;
+        if(!utils.isUUID(module_id) || !utils.isUUID(token)) {
+            return res.send(400);
+        }
+
+        connection.query('SELECT * FROM auth WHERE principal=?', [module_id], function (error, rows, field) {
+            if(!!error){
+                logger.error(error);
+            } else if(rows && rows.length > 0) {
+                var rule = rows[0];
+
+                bcrypt.compare(token, rule.token, function(err, resp) {
+                    if(!resp) return res.send(401);
+
+                    connection.query('DELETE FROM auth WHERE principal=?', [module_id], function (error, rows, field) {
+                        if(!!error){
+                            logger.error(error);
+                        } else {
+                            res.setHeader('Content-Type', 'application/json');
+                            delete rule.token;
+                            res.json(rule);           
+                        }
+                    });
+                });
+            } else {
+                res.send(404);
+            }
+        });
+    });
+
+    return router;
+};

--- a/routes/default.js
+++ b/routes/default.js
@@ -10,6 +10,14 @@ module.exports = function(){
         var delete_marker = req.query['delete'];    
         var unsubscribed = req.query['unsubscribed'];
         var unsubscribeDialog = req.query['unsubscribeDialog'];
+        var module = req.query['module'];
+
+        if(module === "true") {
+            req.session.module_mode=true;
+            if(!req.session.authenticated) {
+                return res.redirect('/login');
+            }
+        } 
 
         if((update_marker || delete_marker || unsubscribed || unsubscribeDialog) && !req.session.authenticated) {
             return res.redirect('/login?redirect=' + encodeURIComponent(req.url));
@@ -25,7 +33,8 @@ module.exports = function(){
             update_marker: update_marker,
             delete_marker: delete_marker,
             unsubscribed: unsubscribed,
-            unsubscribeDialog: unsubscribeDialog
+            unsubscribeDialog: unsubscribeDialog,
+            moduleMode: req.session.module_mode
         };
         res.render('index', options);
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -11,6 +11,7 @@ module.exports = function(app, db) {
     importRoute('authentication');
     importRoute('admin');
     importRoute('rss');
+    importRoute('module');
 
     // REST endpoints
     var routes = require('./api/index');

--- a/routes/module.js
+++ b/routes/module.js
@@ -1,0 +1,52 @@
+var express = require('express');
+var router = express.Router();
+var utils = require('../utils');
+
+module.exports = function(connection) {
+
+    const REQUEST_PROTOCOL = process.env.ATLAS_LINK_PROTOCOL || 'https';
+
+    var show_counts_query = "SELECT id,latitude,longitude,name,url,type, \
+    IF(image is not null, concat(?,'://',?,'/api/marker/',id,'/image'), null) AS image_url, \
+    show_counts,patients,encounters,observations,contact,email,notes,data,openmrs_version,distribution,date_created,date_changed,created_by FROM atlas";
+
+    router.get('/module', function(req, res, next) {
+        res.redirect('/?module=true');
+    });
+
+    /* Get marker related to module */
+    router.post('/module', function (req, res, next) {
+
+        res.header('Access-Control-Allow-Origin', '*');
+
+        var module_id=req.body.module_id;
+        var token=req.body.token;
+        if(!utils.isUUID(module_id) || !utils.isUUID(token)) {
+            return res.send(400);
+        }
+        req.session.module_id=module_id;
+        req.session.module_token=token;
+
+        connection.query('SELECT * FROM auth WHERE principal=?', [module_id], function (error, rows, field) {
+            if(!!error){
+                console.log(error);
+            } else if(rows && rows.length > 0) {
+                connection.query(show_counts_query + ' WHERE id=?', [REQUEST_PROTOCOL, req.headers.host, rows[0].atlas_id], function (error, rows, field) {
+                    if(!!error){
+                        console.log(error);
+                    } else if(rows && rows.length > 0) {
+                        res.setHeader('Content-Type', 'application/json');
+                        delete rows[0].token;
+                        res.json(rows[0]);           
+                    } else {
+                        res.send(404);
+                    }
+                });
+            } else {
+                res.send(404);
+            }
+        });
+    });
+    
+    return router;
+};

--- a/utils.js
+++ b/utils.js
@@ -36,9 +36,9 @@ module.exports = {
     hashToken: async function (token) {
 
         const saltRounds = 10;
-        const salt = await bcrypt.genSalt(saltRounds);
+        const salt = await bcrypt.genSalt(saltRounds); 
         const hash = await bcrypt.hash(token, salt);
-      
+
         return hash;
     },
     
@@ -52,6 +52,11 @@ module.exports = {
         });
     },
 
+    /* Checks whether string is a uuid */
+    isUUID: function(id) {
+        return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);  
+    },
+      
     /* Checks whether url is absolute */
     /* Taken from https://stackoverflow.com/questions/10687099/how-to-test-if-a-url-string-is-absolute-or-relative */
     isUrlAbsolute: function(url) {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -30,9 +30,11 @@
 
     var auth_site = [];
     var moduleUUID = null;
+    var moduleToken = null;
     var counts = {};
     var countsEnabled = 1;
     var moduleHasSite = null;
+    var moduleMode = null;
 
     var currentUser;
     var userEmail;
@@ -129,6 +131,26 @@
       userEmail = $('#user-email').val().trim();
       isAdmin = $('#user-admin').val();
       isAdmin = (isAdmin == 'true'); // converting string to boolean
+      moduleMode = $('#moduleMode').val();
+
+      if(moduleMode === "true") {
+        setTimeout(function() {
+          window.parent.postMessage("atlas loaded","*");
+
+          window.addEventListener("message", function(event) {
+            if(!event.data || typeof event.data !== "string") return;
+            var data = event.data.split(":");
+            if(data.length === 2) {
+              if(data[0] === "module_id") moduleUUID=data[1];
+              if(data[0] === "token") moduleToken=data[1];
+              if(data[0] === "has_site") moduleHasSite=(data[1]==="true"?1:0);
+              if(moduleUUID != null && moduleToken != null && moduleHasSite != null) {
+                initialize();
+              }
+            }
+          }, false);
+        }, 500);
+      }
 
       //If user is logged in
       if(currentUser != "visitor") {
@@ -149,7 +171,7 @@
       }
     });
 
-    setTimeout('initialize()', 500);
+    if(moduleMode !== "true") setTimeout('initialize()', 500);
   </script>
 
 </head>
@@ -235,6 +257,7 @@
 <input type="hidden" id="delete-marker" value= <%= delete_marker?delete_marker:"" %> />
 <input type="hidden" id="unsubscribed" value= <%= unsubscribed?unsubscribed:"" %> />
 <input type="hidden" id="unsubscribeDialog" value= <%= unsubscribeDialog?unsubscribeDialog:"" %> />
+<input type="hidden" id="moduleMode" value= <%= moduleMode?moduleMode:"" %> />
 
 </body>
 


### PR DESCRIPTION
JIRA Issue: https://issues.openmrs.org/browse/ATLAS-195

----- WATCH OUT : BUGGY CODE AHEAD -----

I created a module mode for the module to interact with atlas. But I've a few questions regarding the implementation, like,

- What exactly triggers module mode? Is it the POST sent by the module, or the one sent to the iframe by the parent page? Here, its a post doing it. 'module mode' is stored in the session so that the user can mess around in the iframe and still access module mode. This probably needs to be changed though.

- Are the route names ok?

This PR goes together with this PR: https://github.com/openmrs/openmrs-module-atlas/pull/11

TO DO:
-
- Add server-side checks for whether the marker being linked belongs to the user.