### PR TITLE
ATLAS-169: Added search for markers

### DIFF
--- a/public/css/atlas.css
+++ b/public/css/atlas.css
@@ -285,6 +285,24 @@ span.site-version {
 .dropDownControl:hover{
         background: -webkit-linear-gradient(top,rgb(255,255,255),rgb(230,230,230));
 }
+#search-bar {
+        width: 100%;
+}
+#search-results {
+        position: absolute;
+        margin-top: -4px;
+        min-width: 100%;
+}
+.search-image {
+        height: 28px;
+        width: 28px;
+}
+.search-result {
+        padding: 5px;
+        background-color: white;
+        user-select: none;
+        cursor: pointer
+}
 .glyphicon {
     color: #333333;
     margin-right: 5px;

--- a/public/js/atlas.js
+++ b/public/js/atlas.js
@@ -214,6 +214,8 @@ function initialize() {
     map.controls[google.maps.ControlPosition.TOP_RIGHT].push(share);
     var help = document.getElementById("help");
     map.controls[google.maps.ControlPosition.TOP_RIGHT].push(help);
+    var search = document.getElementById("search");
+    map.controls[google.maps.ControlPosition.TOP_RIGHT].push(search);
 
     if (moduleUUID !== null) {
         var alert = document.getElementById("alert");
@@ -249,12 +251,9 @@ function fetchMarkerSites() {
                 var unsubscribed = document.getElementById('unsubscribed').value;
 
                 if(isValidMarkerId(marker_id) && sites[marker_id]) {
-                    sites[marker_id].infowindow.open(map, sites[marker_id].marker);
-                    sites[marker_id].bubbleOpen = true;
                     google.maps.event.addListenerOnce(map, 'tilesloaded', function(){
                         google.maps.event.addListenerOnce(map, 'tilesloaded', function(){
-                            map.setZoom(8);
-                            map.setCenter(sites[marker_id].marker.getPosition());    
+                            focusMarker(marker_id);
                         });
                     });                
                 } 

--- a/public/js/tools.js
+++ b/public/js/tools.js
@@ -54,7 +54,66 @@ $(function () {
     e.stopPropagation();
     $("#share").popover("toggle")
   });
+  $("#search-bar").val("");
+  $("#search").click(function (e) {
+    resetFadeGroups();
+    showSearchModalBox();
+  });
+  $("#search-bar").bind('input', function() { 
+    resetFadeGroups();
+    var search_term = $(this).val().toLowerCase();
+    var search_results = document.getElementById("search-results");
+    var search_results_html = "";
+    if(!search_term) return;
+    var count=0;
+    Object.keys(sites).forEach(function(id) {
+      if(count>=maxSearchResults) return;
+      var site = sites[id];
+      if(site.siteData.name.toLowerCase().includes(search_term)) {
+        search_results_html += "<div class='search-result' onclick='selectSearchResult(\"" + site.siteData.id + "\")'>";
+        var marker_image = "";
+        getCachedTypes().forEach(function(type) {
+          if(marker_image !== "") return;
+          if(type.name === site.siteData.type) marker_image = type.icon;
+        });
+        search_results_html += "<img class='search-image' src='" + marker_image + "' />";
+        search_results_html += "<b>" + site.siteData.name + "</b>";
+        search_results_html += "</div>";
+        count += 1;
+      }
+    });
+    search_results.innerHTML = search_results_html;
+  });
+  //Toggle search bar if ctrl is pressed
+  $(document).keydown(function(event) {
+    if(event.keyCode === 191) {
+      event.preventDefault();
+      resetFadeGroups();
+      showSearchModalBox();
+    }
+  });
+
 });
+
+function showSearchModalBox() {
+  $("#search-modal").modal({
+    "backdrop"  : true,
+    "keyboard"  : true,
+    "show"      : true
+  });
+  setTimeout(function() {
+    if($("#search-bar").val() === "") {
+      $("#search-bar").focus();
+    } else {
+      $("#search-bar").select();
+    }
+  }, 200);
+}
+
+function selectSearchResult(id) {
+  focusMarker(id);
+  $("#search-modal").modal("hide");
+}
 
 function initDownloadButton() {
   $('#download').click(function () {

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -112,6 +112,24 @@ function getMarkerPosition(nextSite, callback)  {
   return null;
 }
 
+function resetFadeGroups() {
+  Object.keys(sites).forEach(function(id) {
+    var site = sites[id];
+    site.fadeGroup = getFadeGroup(site.siteData);
+  });
+  repaintMarkers();
+}
+
+function focusMarker(id) {
+  if(sites[id].fadeGroup > 3) {
+    $("#fadeCheckbox").click();  
+  }
+  sites[id].infowindow.open(map, sites[id].marker);
+  sites[id].bubbleOpen = true;
+  map.setZoom(8);
+  map.setCenter(sites[id].marker.getPosition());    
+}
+
 function createSite() {
   closeBubbles();
   myPosition = map.getCenter();

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -57,6 +57,7 @@
     var imageData = null;
     var imageError = false;
     var maxImageUploadSize = 150*1024;
+    var maxSearchResults = 20;
     var showAdvancedOptions = false;
     var viewParam = {
       site : null,
@@ -188,6 +189,10 @@
   <i class="fa fa-download"></i> Download
 </div>
 
+<div class="atlas-container loginControl dropDownControl control" title="Search for markers" id="search">
+  <span class="glyphicon glyphicon-search"></span> Search
+</div>
+
 <%if (user != null) { %>
 <div class="atlas-container control logged" id ="login">
   <div class="dropDownControl" id="user"><span class="glyphicon glyphicon-user"></span> <%= user.uid %></div>
@@ -244,6 +249,25 @@
 
   </div>
 
+</div>
+
+<!-- set up the modal to start hidden and fade in and out -->
+<div id="search-modal" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <div class="modal-body">
+        <div id="search-div">
+          <input type="text" id="search-bar" placeholder="Search for markers"/>
+        </div>
+      </div>
+
+      <div id="search-results">
+
+      </div>
+
+    </div>
+  </div>
 </div>
 
 <div id='atlas-hidden-latitude' style='hidden:true;'></div>


### PR DESCRIPTION
JIRA issue: https://issues.openmrs.org/browse/ATLAS-169

The markers' names are checked to see if they contain the search term as a substring. If no, the sites are hidden. Clicking search displays a clear button which can be clicked to revert the map to normal. Is there anything that you'd like to improve about the PR?

The changes can be tested on [staging](https://atlas-stg.openmrs.org/).

![Screenshot from 2019-08-07 13-34-49](https://user-images.githubusercontent.com/34064492/62605674-3b7e5700-b918-11e9-9608-d9ff2e4149a6.png)
