### PR TITLE
[GCI-341] Update readme in opennmrs-contrib-atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ OpenMRS-contrib-atlas-node is the server code written in nodejs for [OpenMRS ATL
   - create environment variables in your bash
       ```sh
         export DB_HOST='localhost'
-        export DB_USERNAME='root'
-        export DB_PASSWORD='root'
+        export DB_USERNAME='<mysql username>'
+        export DB_PASSWORD='<mysql password>'
         export DB_NAME='atlasdb'
         export GOOGLE_MAPS_JS_API_KEY='<your google api key>'
         ```


### PR DESCRIPTION
Jira issue: https://issues.openmrs.org/browse/GCI-341

Under "create environment variables in your bash", `DB_USERNAME` and `DB_PASSWORD`'s values have been replaced with `<mysql username>` and `<mysql password>` respectively.